### PR TITLE
Fix prod pypi upload URL

### DIFF
--- a/.github/workflows/build-and-publish-new-version.yml
+++ b/.github/workflows/build-and-publish-new-version.yml
@@ -171,4 +171,4 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
-          repository_url: https://pypi.org/legacy/
+          repository_url: https://upload.pypi.org/legacy/


### PR DESCRIPTION
This is a fix for https://github.com/CentML/skyline/actions/runs/3056212464/jobs/4930157936