### PR TITLE
Fix packaging

### DIFF
--- a/.github/workflows/build-and-publish-new-version.yml
+++ b/.github/workflows/build-and-publish-new-version.yml
@@ -27,14 +27,10 @@ jobs:
         with:
           virtualenvs-in-project: true
 
-      - name: Copy pyproject.toml
-        run: |
-          cp pyproject.toml ./skyline/
-          NEXT_CLI_VERSION=$(poetry version --short)
-          echo "NEXT_CLI_VERSION=$NEXT_CLI_VERSION" >> $GITHUB_ENV
-
       - name: Build Python package
         run: |
+          NEXT_CLI_VERSION=$(poetry version --short)
+          echo "NEXT_CLI_VERSION=$NEXT_CLI_VERSION" >> $GITHUB_ENV
           poetry build
 
       - name: Upload Artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,6 @@
 # Created by https://www.toptal.com/developers/gitignore/api/python,osx,pycharm,visualstudiocode
 # Edit at https://www.toptal.com/developers/gitignore?templates=python,osx,pycharm,visualstudiocode
 
-### Skyline ###
-skyline/pyproject.toml
-
 ### OSX ###
 # General
 .DS_Store

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "skyline-profiler"
 version = "0.11.1"
 description = "Interactive performance profiling and debugging tool for PyTorch neural networks."
 authors = ["Geoffrey Yu <gxyu@cs.toronto.edu>"]
-maintainers = ["Akbar Nurlybayev <akbar@centml.ai>", "Yubo Gao <ybgao@centml.ai>", ]
+maintainers = ["Akbar Nurlybayev <akbar@centml.ai>", "Yubo Gao <ybgao@centml.ai>"]
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/CentML/skyline"
@@ -18,6 +18,8 @@ classifiers = [
 packages = [
     { include = "skyline" },
 ]
+
+include = [ "pyproject.toml" ]
 
 [tool.poetry.scripts]
 skyline = "skyline.skyline:main"

--- a/tools/prepare-release.sh
+++ b/tools/prepare-release.sh
@@ -4,7 +4,7 @@
 # Release steps:
 # 1. Create release branch
 # 2. Increment package version in pyproject.toml
-# 3. Prepare change log since the last version 
+# 3. Prepare change log since the last version
 # 4. Commit the change log
 # 5. Creater draft Github release
 # 6. Optional: create ability to publish to test pypi
@@ -27,9 +27,9 @@ echo ""
 check_tools
 
 CURR_CLI_VERSION=$(poetry version --short)
-echo -en "${COLOR_YELLOW}Release increment: [patch], minor, major${COLOR_NC}"
+echo -en "${COLOR_YELLOW}Release increment: [patch], minor, major ${COLOR_NC}"
 read -r
-case $REPLY in 
+case $REPLY in
 major)
   poetry version major;;
 minor)
@@ -75,7 +75,7 @@ gh pr create --title "Release $VERSION_TAG" --body "$RELEASE_NOTES"
 # echo -en "${COLOR_YELLOW}Ready to publish? [dryrun], test-pypi, pypi${COLOR_NC}"
 # read -r
 # echo ""
-# case $REPLY in 
+# case $REPLY in
 # test-pypi)
 #   echo_yellow "> Releasing $VERSION_TAG of the CLI..."
 #   publish_to_pypi;;


### PR DESCRIPTION
Looks like `poetry` behaviour changed between versions 0.11 and 0.12, whereas `poetry build` would exclude non-source files despite their proximity with source code. Adding explicit include of the `pyproject.toml` makes sure that it is included with the .whl in the correct path as before.

Here is how I tested:
```zsh
# from skyline root
poetry install
poetry build

cd ..
mkdir -p test-skyline
cd test-skyline
poetry init
poetry add ../skyline/dist/skyline_profiler*.whl
poetry run skyline -h

```