### PR TITLE
Decrementing protobuf to previous major version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -16,7 +16,7 @@ python-versions = "*"
 
 [[package]]
 name = "protobuf"
-version = "4.21.6"
+version = "3.18.3"
 description = ""
 category = "main"
 optional = false


### PR DESCRIPTION
Due to changes outlined here (https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates), we need to decrement the protobuf version for now. If we want to upgrade it, we need to regenerate the upb2 code with the update version of protobuf.