### PR TITLE
Removed print statement in __init__.py

### DIFF
--- a/skyline/__init__.py
+++ b/skyline/__init__.py
@@ -4,8 +4,6 @@ import toml
 
 file_path = os.path.abspath(__file__)
 dir_path = os.path.dirname(file_path)
-print(dir_path)
-print(os.path.join("..", dir_path, "pyproject.toml"))
 package = toml.load(os.path.join(dir_path, "..", "pyproject.toml"))
 
 __name__ = package["tool"]["poetry"]["name"]


### PR DESCRIPTION
Removed print statements from skyline/__init__.py so there are no print statements when importing skyline