### PR TITLE
Add nix support to skyline

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,80 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1669052418,
+        "narHash": "sha256-M1I4BKXBQm2gey1tScemEh5TpHHE3gKptL7BpWUvL8s=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "20fc948445a6c22d4e8d5178e9a6bc6e1f5417c8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "poetry2nix": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1669070813,
+        "narHash": "sha256-Z8FxcJfG7cIAIjMvGU0jr1K1oWCM/DDnlU7i8LsrkKY=",
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "rev": "686a2d4ee4f00244b80396d1948e3b38000df6e8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "poetry2nix": "poetry2nix"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,94 @@
+{
+  description = "Application packaged using poetry2nix";
+
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.poetry2nix = {
+    url = "github:nix-community/poetry2nix";
+    inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, poetry2nix }:
+    {
+      # Nixpkgs overlay providing the application
+      overlay = nixpkgs.lib.composeManyExtensions [
+        poetry2nix.overlay
+        (final: prev: {
+          # The application
+          skyline = prev.poetry2nix.mkPoetryApplication {
+            projectDir = ./.;
+          };
+        })
+      ];
+    } // (flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ self.overlay ];
+        };
+      in
+      {
+        apps = {
+          skyline = pkgs.myapp;
+        };
+
+        defaultApp = pkgs.skyline;
+
+        devShell = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            (python39.withPackages (ps: with ps; [ poetry ]))
+          ];
+          packages = with pkgs; [
+           autoconf
+           automake
+           binutils
+           boost
+           clang
+           cmake
+           cudaPackages.cuda_cupti
+           cudatoolkit
+           curl
+           freeglut
+           git
+           gitRepo
+           gnome.gnome-keyring # needed for `typed-extensions` to compile`
+           gnumake
+           gnupg
+           gperf
+           libGL
+           libGLU
+           linuxPackages.nvidia_x11
+           m4
+           ncurses5
+           ninja
+           openvscode-server
+           poetry
+           procps
+           python39
+           python39Packages.ipython
+           python39Packages.jupyter
+           python39Packages.pip
+           python39Packages.setuptools
+           stdenv.cc
+           unzip
+           util-linux
+           xorg.libX11
+           xorg.libXext
+           xorg.libXi
+           xorg.libXmu
+           xorg.libXrandr
+           xorg.libXv
+           zlib 
+         ];
+         shellHook = with pkgs; ''
+            export CUDA_PATH=${cudatoolkit}
+            export LD_LIBRARY_PATH="${linuxPackages.nvidia_x11}/lib:${ncurses5}/lib:${stdenv.cc.cc.lib}/lib:/run/opengl-driver/lib/"
+            export EXTRA_LDFLAGS="-L/lib -L${linuxPackages.nvidia_x11}/lib"
+            export EXTRA_CCFLAGS="-I/usr/include"
+         '';          
+        };
+     }
+    )
+  );
+}
+

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
 
         devShell = pkgs.mkShell {
           buildInputs = with pkgs; [
-            (python39.withPackages (ps: with ps; [ poetry ]))
+            (python39.withPackages (ps: with ps; [ poetry ipython jupyter pip setuptools ]))
           ];
           packages = with pkgs; [
            autoconf
@@ -62,13 +62,7 @@
            ncurses5
            ninja
            openvscode-server
-           poetry
            procps
-           python39
-           python39Packages.ipython
-           python39Packages.jupyter
-           python39Packages.pip
-           python39Packages.setuptools
            stdenv.cc
            unzip
            util-linux


### PR DESCRIPTION
This PR adds WIP support for Nix.

At the moment, this repo depends on Nix flake support being enabled; future versions may support legacy Nix idioms like `shell.nix` etc.  Of course, those won't allow e.g. specifying a system config down to the kernel driver, which is an opportunity that Nix flakes open up.  (TODO)

This config was generated according to the instructions in the README.md of [poetry2nix](https://github.com/nix-community/poetry2nix), which allows nix to use the poetry config directly.  To be specific: this config was was instantiated by running `nix flake init --template github:nix-community/poetry2nix` and then customizing the output of the template. 

At the moment, there are a few packages I added to the default config 'for good measure', i.e. because they're often desired; c compiler, automake, etc. It might make sense to remove some, but not all, of these. 

I also include jupyter and vscode-server, so that these may be run from within the closure. This ensures that the .vsix is being hosted within the closure, and can see the same CUDA libs that skyline can.

This is alpha support and it is not to be depended upon quite just yet. That said, it's a good first stab at Nix support. 

