### PR TITLE
Ensure we account for device names with suffixes

### DIFF
--- a/skyline/analysis/session.py
+++ b/skyline/analysis/session.py
@@ -171,9 +171,11 @@ class AnalysisSession:
         # TODO: Consider profiling on not only the first detected GPU
         nvml_handle = pynvml.nvmlDeviceGetHandleByIndex(0)
         source_device_name = pynvml.nvmlDeviceGetName(nvml_handle).decode("utf-8")
+        source_device_name_split = source_device_name.split()
         source_device = habitat.Device.T4
         for device in DEVICES:
-            if device.name in source_device_name.split(" "):
+            if any(device.name in source_device_partial_name \
+                for source_device_partial_name in source_device_name_split):
                 source_device = device
         pynvml.nvmlShutdown()
 

--- a/skyline/analysis/session.py
+++ b/skyline/analysis/session.py
@@ -4,6 +4,7 @@ import logging
 import math
 import os
 import pynvml
+import re
 
 import torch
 import numpy as np
@@ -171,11 +172,10 @@ class AnalysisSession:
         # TODO: Consider profiling on not only the first detected GPU
         nvml_handle = pynvml.nvmlDeviceGetHandleByIndex(0)
         source_device_name = pynvml.nvmlDeviceGetName(nvml_handle).decode("utf-8")
-        source_device_name_split = source_device_name.split()
+        split_source_device_name = re.split(r"-|\s|_|\\|/", source_device_name)
         source_device = habitat.Device.T4
         for device in DEVICES:
-            if any(device.name in source_device_partial_name \
-                for source_device_partial_name in source_device_name_split):
+            if device.name in split_source_device_name:
                 source_device = device
         pynvml.nvmlShutdown()
 


### PR DESCRIPTION
I noticed after running the ML Tools test, the source device was T4 even if it was actually P100 or V100. This bug occurred because the device names had additional suffixes (e.g. P100 had the name Tesla P100-PCIE-16GB). 

Originally Skyline split the string on whitespaces and checked if the name is an exact match with any of those split strings. Now it will check if the name is a substring of the split strings.

I wish there was a better solution for this because this still seems fragile.