### PR TITLE
Removed all references to Atom

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Once your entry point file is ready, there are two ways to profile interactive p
 
 ### Interactive Profiling
 ```zsh
-poetry run skyline interactive --skip-atom path/to/entry/point/file
+poetry run skyline interactive
 ```
 
 ### Standalone Profiling

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -2,7 +2,7 @@
 The current support for remote projects is meant for *advanced users*. We are working on a more user-friendly process for setting up a remote project that we will ship in a future release.
 
 ## Terminology
-- **Client:** The local machine where you run Atom and the Skyline plugin.
+- **Client:** The local machine where you run the Skyline plugin.
 - **Server:** The remote machine where you want to run the Skyline profiler.
 
 ## Prerequisites
@@ -25,23 +25,17 @@ ssh -L 60210:localhost:60210 <server hostname>
 Skyline uses port 60210 by default, so we recommend forwarding that port. If your server exposes ports, you do not need to set up an SSH tunnel and can use one of the open ports instead.
 
 ### Starting the Skyline Profiler
-After connecting to the server, you can start the Skyline profiler by navigating to your project root and running the `skyline interactive` command as usual, but with the `--skip-atom` flag added. This flag prevents Skyline from attempting to launch Atom (since you will be running it on your client machine).
+After connecting to the server, you can start the Skyline profiler by navigating to your project root and running the `skyline interactive` command as usual.
 
 ```zsh
-pipenv run skyline interactive your_entry_point.py --skip-atom
+pipenv run skyline interactive
 ```
 
 If you want to use a different port, you can use the `--port` flag to tell the profiler to listen on a different port.
 
 ```zsh
-pipenv skyline interactive your_entry_point.py --skip-atom --port 1337
+pipenv skyline interactive --port 1337
 ```
 
 ### Starting the Skyline Plugin
-Launch Atom and open Skyline by running the `Skyline:Toggle` command in the command palette (Ctrl-Shift-P on Ubuntu, ⌘-Shift-P on macOS). You can also launch Skyline using the Atom menus: Packages > Skyline > Show/Hide Skyline.
-
-Now, *instead* of hitting Connect, click the button next to it with a gear icon. Three text fields should appear. If you are using an SSH tunnel to connect to the Skyline profiler, you do not need to change the host and port (the first two text boxes). If you are connecting to a custom port on the server machine, enter the correct host and port.
-
-Next, you need to specify the absolute path to the project root on the client machine. A quick way of doing this is to open a project file in Atom and then click the button next to the text field. Skyline will fill in the project root using the path to that file. You can then edit the path to correct it if needed.
-
-Once all three fields have been filled in, you can click the Connect button to start your profiling session. If everything was set up correctly, you will be able to use Skyline with your remote project!
+Launch VSCode and open Skyline by running the `Skyline` command in the command palette (Ctrl-Shift-P on Ubuntu, ⌘-Shift-P on macOS). 

--- a/skyline/commands/interactive.py
+++ b/skyline/commands/interactive.py
@@ -45,26 +45,7 @@ def register_command(subparsers):
     )
     parser.add_argument(
         "--debug", action="store_true", help="Log debug messages.")
-    parser.add_argument(
-        "--skip-atom",
-        action="store_true",
-        help="Skip launching Atom.",
-    )
     parser.set_defaults(func=main)
-
-
-def launch_atom():
-    try:
-        # The atom command line executable returns by default after launching
-        # Atom (i.e. it does not block and wait until Atom is closed).
-        subprocess.run(["atom", "--no-sandbox", "atom://skyline"], check=True)
-    except FileNotFoundError:
-        logger.warn(
-            "Skyline was not able to launch Atom from the command line. "
-            "Please make sure that Atom is installed and then launch Atom "
-            "manually to use Skyline's interactive profiling interface.",
-        )
-
 
 def actual_main(args):
     from skyline.config import Config
@@ -78,8 +59,6 @@ def actual_main(args):
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)
 
-    if not args.skip_atom:
-        launch_atom()
 
     with SkylineServer(args.host, args.port) as server:
         _, port = server.listening_on

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,13 +1,8 @@
-
-import argparse
-import json
 import os
 import socket
 import struct
 import subprocess
-import pytest
 import threading
-from termcolor import colored
 
 from skyline.protocol_gen import innpv_pb2
 
@@ -47,7 +42,7 @@ class BackendContext:
         # Skyline expects the entry_point filename to be relative
         working_dir = os.path.dirname(self.entry_point)
         entry_filename = os.path.basename(self.entry_point)
-        launch_command = [self.skyline_bin, "interactive", "--skip-atom", entry_filename]
+        launch_command = [self.skyline_bin, "interactive", entry_filename]
 
         # Launch backend + listener threads for stdout and stderr
         self.process = subprocess.Popen(launch_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=working_dir)


### PR DESCRIPTION
- Updated README and other documentation
- Removed references to Atom in command arguments when launching Skyline