### PR TITLE
Add fast Python linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 [![License](https://img.shields.io/badge/license-Apache--2.0-green?style=flat)](https://github.com/CentML/skyline/blob/main/LICENSE)
 ![](https://img.shields.io/pypi/pyversions/skyline-profiler.svg)
 [![](https://img.shields.io/pypi/v/skyline-profiler.svg)](https://pypi.org/project/skyline-profiler/)
+[![Maintainability](https://api.codeclimate.com/v1/badges/632822d0143726b53610/maintainability)](https://codeclimate.com/github/CentML/DeepView.Profile/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/632822d0143726b53610/test_coverage)](https://codeclimate.com/github/CentML/DeepView.Profile/test_coverage)
 
 Skyline is a tool to profile and debug the training performance of [PyTorch](https://pytorch.org) neural networks.
 

--- a/examples/densenet/densenet.py
+++ b/examples/densenet/densenet.py
@@ -1,11 +1,9 @@
-import re
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.utils.checkpoint as cp
 from collections import OrderedDict
 from torch import Tensor
-from torch.jit.annotations import List
 
 
 class _DenseLayer(nn.Module):

--- a/examples/densenet/entry_point.py
+++ b/examples/densenet/entry_point.py
@@ -1,5 +1,4 @@
 import torch
-import torch.nn as nn
 
 import densenet
 

--- a/examples/gnmt/entry_point.py
+++ b/examples/gnmt/entry_point.py
@@ -4,10 +4,8 @@ from ast import literal_eval
 import torch
 import torch.nn as nn
 import torch.optim
-import torch.distributed as dist
 
 import seq2seq.data.config as config
-import seq2seq.utils as utils
 from seq2seq.models.gnmt import GNMT
 from seq2seq.train.fp_optimizers import Fp32Optimizer
 from seq2seq.train.lr_scheduler import WarmupMultiStepLR

--- a/examples/gnmt/seq2seq/data/sampler.py
+++ b/examples/gnmt/seq2seq/data/sampler.py
@@ -5,7 +5,6 @@ from torch.utils.data.sampler import Sampler
 
 from seq2seq.utils import get_rank
 from seq2seq.utils import get_world_size
-from seq2seq.utils import gnmt_print
 
 
 class DistributedSampler(Sampler):

--- a/examples/gnmt/seq2seq/data/tokenizer.py
+++ b/examples/gnmt/seq2seq/data/tokenizer.py
@@ -56,7 +56,7 @@ class Tokenizer:
         assert len(vocab) % pad == 0
 
     def get_state(self):
-        logging.info(f'Saving state of the tokenizer')
+        logging.info('Saving state of the tokenizer')
         state = {
             'separator': self.separator,
             'vocab_size': self.vocab_size,
@@ -66,7 +66,7 @@ class Tokenizer:
         return state
 
     def set_state(self, state):
-        logging.info(f'Restoring state of the tokenizer')
+        logging.info('Restoring state of the tokenizer')
         self.separator = state['separator']
         self.vocab_size = state['vocab_size']
         self.tok2idx = state['tok2idx']

--- a/examples/gnmt/seq2seq/inference/beam_search.py
+++ b/examples/gnmt/seq2seq/inference/beam_search.py
@@ -2,7 +2,6 @@ import torch
 
 from seq2seq.data.config import BOS
 from seq2seq.data.config import EOS
-from seq2seq.utils import gnmt_print
 
 
 class SequenceGenerator:

--- a/examples/gnmt/seq2seq/inference/inference.py
+++ b/examples/gnmt/seq2seq/inference/inference.py
@@ -113,7 +113,7 @@ class Translator:
             os.remove(detok_eval_path)
 
         rank = get_rank()
-        logging.info(f'Running evaluation on test set')
+        logging.info('Running evaluation on test set')
         self.model.eval()
         torch.cuda.empty_cache()
 
@@ -131,12 +131,12 @@ class Translator:
                     logging.info(f'BLEU on test dataset: {test_bleu[0]:.2f}')
 
                 if self.target_bleu and test_bleu[0] >= self.target_bleu:
-                    logging.info(f'Target accuracy reached')
+                    logging.info('Target accuracy reached')
                     break_training[0] = 1
 
         barrier()
         torch.cuda.empty_cache()
-        logging.info(f'Finished evaluation on test set')
+        logging.info('Finished evaluation on test set')
 
         if self.distributed:
             dist.broadcast(break_training, 0)
@@ -220,7 +220,7 @@ class Translator:
 
             if i % self.print_freq == 0:
                 log = []
-                log += f'TEST '
+                log += 'TEST '
                 if epoch is not None:
                     log += f'[{epoch}]'
                 if iteration is not None:
@@ -241,7 +241,7 @@ class Translator:
         if summary and get_rank() == 0:
             time_per_sentence = (batch_time.avg / global_batch_size)
             log = []
-            log += f'TEST SUMMARY:\n'
+            log += 'TEST SUMMARY:\n'
             log += f'Lines translated: {len(self.loader.dataset)}\t'
             log += f'Avg total tokens/s: {tot_tok_per_sec.avg:.0f}\n'
             log += f'Avg time per batch: {batch_time.avg:.3f} s\t'

--- a/examples/gnmt/seq2seq/models/gnmt.py
+++ b/examples/gnmt/seq2seq/models/gnmt.py
@@ -4,7 +4,6 @@ import seq2seq.data.config as config
 from seq2seq.models.decoder import ResidualRecurrentDecoder
 from seq2seq.models.encoder import ResidualRecurrentEncoder
 from seq2seq.models.seq2seq_base import Seq2Seq
-from seq2seq.utils import gnmt_print
 
 
 class GNMT(Seq2Seq):

--- a/examples/gnmt/seq2seq/train/lr_scheduler.py
+++ b/examples/gnmt/seq2seq/train/lr_scheduler.py
@@ -3,7 +3,6 @@ import math
 
 import torch
 
-from seq2seq.utils import gnmt_print
 
 
 def perhaps_convert_float(param, total):
@@ -64,8 +63,8 @@ class WarmupMultiStepLR(torch.optim.lr_scheduler._LRScheduler):
         self.decay_steps = decay_steps
 
         if self.warmup_steps > self.remain_steps:
-            logging.warn(f'warmup_steps should not be larger than '
-                         f'remain_steps, setting warmup_steps=remain_steps')
+            logging.warn('warmup_steps should not be larger than '
+                         'remain_steps, setting warmup_steps=remain_steps')
             self.warmup_steps = self.remain_steps
 
         super(WarmupMultiStepLR, self).__init__(optimizer, last_epoch)

--- a/examples/gnmt/seq2seq/train/trainer.py
+++ b/examples/gnmt/seq2seq/train/trainer.py
@@ -13,7 +13,6 @@ from seq2seq.train.fp_optimizers import Fp16Optimizer
 from seq2seq.train.fp_optimizers import Fp32Optimizer
 from seq2seq.train.lr_scheduler import WarmupMultiStepLR
 from seq2seq.utils import AverageMeter
-from seq2seq.utils import gnmt_print
 from seq2seq.utils import sync_workers
 
 

--- a/examples/legacy/testnet2.py
+++ b/examples/legacy/testnet2.py
@@ -1,4 +1,3 @@
-import torch
 import torch.nn as nn
 
 

--- a/examples/legacy/vgg11.py
+++ b/examples/legacy/vgg11.py
@@ -1,4 +1,3 @@
-import torch
 import torch.nn as nn
 
 

--- a/examples/resnet/entry_point.py
+++ b/examples/resnet/entry_point.py
@@ -1,5 +1,4 @@
 import torch
-import torch.nn as nn
 
 import resnet
 

--- a/examples/resnet/entry_point_resnext.py
+++ b/examples/resnet/entry_point_resnext.py
@@ -1,5 +1,4 @@
 import torch
-import torch.nn as nn
 
 import resnet
 

--- a/examples/testnet/testnet1.py
+++ b/examples/testnet/testnet1.py
@@ -1,4 +1,3 @@
-import torch
 import torch.nn as nn
 
 

--- a/examples/transformer/transformer/Beam.py
+++ b/examples/transformer/transformer/Beam.py
@@ -6,7 +6,6 @@
 """
 
 import torch
-import numpy as np
 import transformer.Constants as Constants
 
 class Beam():

--- a/examples/vgg/entry_point.py
+++ b/examples/vgg/entry_point.py
@@ -1,5 +1,4 @@
 import torch
-import torch.nn as nn
 
 import vgg
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -14,6 +14,10 @@ category = "main"
 optional = false
 python-versions = ">=3"
 
+[package.dependencies]
+setuptools = "*"
+wheel = "*"
+
 [[package]]
 name = "nvidia-cuda-nvrtc-cu11"
 version = "11.7.99"
@@ -21,6 +25,10 @@ description = "NVRTC native runtime libraries"
 category = "main"
 optional = false
 python-versions = ">=3"
+
+[package.dependencies]
+setuptools = "*"
+wheel = "*"
 
 [[package]]
 name = "nvidia-cuda-runtime-cu11"
@@ -30,6 +38,10 @@ category = "main"
 optional = false
 python-versions = ">=3"
 
+[package.dependencies]
+setuptools = "*"
+wheel = "*"
+
 [[package]]
 name = "nvidia-cudnn-cu11"
 version = "8.5.0.96"
@@ -37,6 +49,10 @@ description = "cuDNN runtime libraries"
 category = "main"
 optional = false
 python-versions = ">=3"
+
+[package.dependencies]
+setuptools = "*"
+wheel = "*"
 
 [[package]]
 name = "nvidia-ml-py3"
@@ -76,6 +92,27 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "ruff"
+version = "0.0.254"
+description = "An extremely fast Python linter, written in Rust."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "setuptools"
+version = "67.6.0"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+
+[[package]]
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
@@ -109,21 +146,197 @@ category = "main"
 optional = false
 python-versions = ">=3.7"
 
+[[package]]
+name = "wheel"
+version = "0.38.4"
+description = "A built-package format for Python"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+test = ["pytest (>=3.0.0)"]
+
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "9ef847cc37187c3ac9c9d15c14106fcf4a6e3a8e37f76f01dede2a55f8246db9"
+content-hash = "365a5f35d21fa351b3c2cafc5007e9a0b58fcbd9f4b77280261ddde213d90b92"
 
 [metadata.files]
-numpy = []
-nvidia-cublas-cu11 = []
-nvidia-cuda-nvrtc-cu11 = []
-nvidia-cuda-runtime-cu11 = []
-nvidia-cudnn-cu11 = []
-nvidia-ml-py3 = []
-protobuf = []
-pyrapl = []
-pyyaml = []
-toml = []
-torch = []
-typing-extensions = []
+numpy = [
+    {file = "numpy-1.21.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:38e8648f9449a549a7dfe8d8755a5979b45b3538520d1e735637ef28e8c2dc50"},
+    {file = "numpy-1.21.1-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:fd7d7409fa643a91d0a05c7554dd68aa9c9bb16e186f6ccfe40d6e003156e33a"},
+    {file = "numpy-1.21.1-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a75b4498b1e93d8b700282dc8e655b8bd559c0904b3910b144646dbbbc03e062"},
+    {file = "numpy-1.21.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1412aa0aec3e00bc23fbb8664d76552b4efde98fb71f60737c83efbac24112f1"},
+    {file = "numpy-1.21.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e46ceaff65609b5399163de5893d8f2a82d3c77d5e56d976c8b5fb01faa6b671"},
+    {file = "numpy-1.21.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:c6a2324085dd52f96498419ba95b5777e40b6bcbc20088fddb9e8cbb58885e8e"},
+    {file = "numpy-1.21.1-cp37-cp37m-win32.whl", hash = "sha256:73101b2a1fef16602696d133db402a7e7586654682244344b8329cdcbbb82172"},
+    {file = "numpy-1.21.1-cp37-cp37m-win_amd64.whl", hash = "sha256:7a708a79c9a9d26904d1cca8d383bf869edf6f8e7650d85dbc77b041e8c5a0f8"},
+    {file = "numpy-1.21.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:95b995d0c413f5d0428b3f880e8fe1660ff9396dcd1f9eedbc311f37b5652e16"},
+    {file = "numpy-1.21.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:635e6bd31c9fb3d475c8f44a089569070d10a9ef18ed13738b03049280281267"},
+    {file = "numpy-1.21.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:4a3d5fb89bfe21be2ef47c0614b9c9c707b7362386c9a3ff1feae63e0267ccb6"},
+    {file = "numpy-1.21.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:8a326af80e86d0e9ce92bcc1e65c8ff88297de4fa14ee936cb2293d414c9ec63"},
+    {file = "numpy-1.21.1-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:791492091744b0fe390a6ce85cc1bf5149968ac7d5f0477288f78c89b385d9af"},
+    {file = "numpy-1.21.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0318c465786c1f63ac05d7c4dbcecd4d2d7e13f0959b01b534ea1e92202235c5"},
+    {file = "numpy-1.21.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9a513bd9c1551894ee3d31369f9b07460ef223694098cf27d399513415855b68"},
+    {file = "numpy-1.21.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:91c6f5fc58df1e0a3cc0c3a717bb3308ff850abdaa6d2d802573ee2b11f674a8"},
+    {file = "numpy-1.21.1-cp38-cp38-win32.whl", hash = "sha256:978010b68e17150db8765355d1ccdd450f9fc916824e8c4e35ee620590e234cd"},
+    {file = "numpy-1.21.1-cp38-cp38-win_amd64.whl", hash = "sha256:9749a40a5b22333467f02fe11edc98f022133ee1bfa8ab99bda5e5437b831214"},
+    {file = "numpy-1.21.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:d7a4aeac3b94af92a9373d6e77b37691b86411f9745190d2c351f410ab3a791f"},
+    {file = "numpy-1.21.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d9e7912a56108aba9b31df688a4c4f5cb0d9d3787386b87d504762b6754fbb1b"},
+    {file = "numpy-1.21.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:25b40b98ebdd272bc3020935427a4530b7d60dfbe1ab9381a39147834e985eac"},
+    {file = "numpy-1.21.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:8a92c5aea763d14ba9d6475803fc7904bda7decc2a0a68153f587ad82941fec1"},
+    {file = "numpy-1.21.1-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:05a0f648eb28bae4bcb204e6fd14603de2908de982e761a2fc78efe0f19e96e1"},
+    {file = "numpy-1.21.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f01f28075a92eede918b965e86e8f0ba7b7797a95aa8d35e1cc8821f5fc3ad6a"},
+    {file = "numpy-1.21.1-cp39-cp39-win32.whl", hash = "sha256:88c0b89ad1cc24a5efbb99ff9ab5db0f9a86e9cc50240177a571fbe9c2860ac2"},
+    {file = "numpy-1.21.1-cp39-cp39-win_amd64.whl", hash = "sha256:01721eefe70544d548425a07c80be8377096a54118070b8a62476866d5208e33"},
+    {file = "numpy-1.21.1-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:2d4d1de6e6fb3d28781c73fbde702ac97f03d79e4ffd6598b880b2d95d62ead4"},
+    {file = "numpy-1.21.1.zip", hash = "sha256:dff4af63638afcc57a3dfb9e4b26d434a7a602d225b42d746ea7fe2edf1342fd"},
+]
+nvidia-cublas-cu11 = [
+    {file = "nvidia_cublas_cu11-11.10.3.66-py3-none-manylinux1_x86_64.whl", hash = "sha256:d32e4d75f94ddfb93ea0a5dda08389bcc65d8916a25cb9f37ac89edaeed3bded"},
+    {file = "nvidia_cublas_cu11-11.10.3.66-py3-none-win_amd64.whl", hash = "sha256:8ac17ba6ade3ed56ab898a036f9ae0756f1e81052a317bf98f8c6d18dc3ae49e"},
+]
+nvidia-cuda-nvrtc-cu11 = [
+    {file = "nvidia_cuda_nvrtc_cu11-11.7.99-2-py3-none-manylinux1_x86_64.whl", hash = "sha256:9f1562822ea264b7e34ed5930567e89242d266448e936b85bc97a3370feabb03"},
+    {file = "nvidia_cuda_nvrtc_cu11-11.7.99-py3-none-manylinux1_x86_64.whl", hash = "sha256:f7d9610d9b7c331fa0da2d1b2858a4a8315e6d49765091d28711c8946e7425e7"},
+    {file = "nvidia_cuda_nvrtc_cu11-11.7.99-py3-none-win_amd64.whl", hash = "sha256:f2effeb1309bdd1b3854fc9b17eaf997808f8b25968ce0c7070945c4265d64a3"},
+]
+nvidia-cuda-runtime-cu11 = [
+    {file = "nvidia_cuda_runtime_cu11-11.7.99-py3-none-manylinux1_x86_64.whl", hash = "sha256:cc768314ae58d2641f07eac350f40f99dcb35719c4faff4bc458a7cd2b119e31"},
+    {file = "nvidia_cuda_runtime_cu11-11.7.99-py3-none-win_amd64.whl", hash = "sha256:bc77fa59a7679310df9d5c70ab13c4e34c64ae2124dd1efd7e5474b71be125c7"},
+]
+nvidia-cudnn-cu11 = [
+    {file = "nvidia_cudnn_cu11-8.5.0.96-2-py3-none-manylinux1_x86_64.whl", hash = "sha256:402f40adfc6f418f9dae9ab402e773cfed9beae52333f6d86ae3107a1b9527e7"},
+    {file = "nvidia_cudnn_cu11-8.5.0.96-py3-none-manylinux1_x86_64.whl", hash = "sha256:71f8111eb830879ff2836db3cccf03bbd735df9b0d17cd93761732ac50a8a108"},
+]
+nvidia-ml-py3 = [
+    {file = "nvidia-ml-py3-7.352.0.tar.gz", hash = "sha256:390f02919ee9d73fe63a98c73101061a6b37fa694a793abf56673320f1f51277"},
+]
+protobuf = [
+    {file = "protobuf-3.18.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:370a6b885e94adda021d4cbe43accdfbf6a02af651a0be337a28906a3fa77f3d"},
+    {file = "protobuf-3.18.3-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6741d7d1cfcbdd6cf610f38b7976cf8c0b41022203555298925e4061b6616608"},
+    {file = "protobuf-3.18.3-cp36-cp36m-win32.whl", hash = "sha256:3149c373e9b7ce296bb24d42a3eb677d620185b5dff2c390b2cf57baf79afdc1"},
+    {file = "protobuf-3.18.3-cp36-cp36m-win_amd64.whl", hash = "sha256:850da2072d98c6e576b7eb29734cdde6fd9f5d157e43d7818d79f4b373ef5d51"},
+    {file = "protobuf-3.18.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0c44e01f74109decea196b5b313b08edb5316df77313995594a6981e95674259"},
+    {file = "protobuf-3.18.3-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:85d1fb5ff1d638a0045bbe4f01a8f287023aa4f2b29011445b1be0edc74a2103"},
+    {file = "protobuf-3.18.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cde2a73b03049b904dbc5d0f500b97e11abb4109dbe2940e6a1595e2eef4e8a9"},
+    {file = "protobuf-3.18.3-cp37-cp37m-win32.whl", hash = "sha256:b03966ca4d1aa7850f5bf0d841c22a8eeb6ce091f77e585ffeb8b95a6b0a96c4"},
+    {file = "protobuf-3.18.3-cp37-cp37m-win_amd64.whl", hash = "sha256:d52a687e2c74c40f45abd6906f833d4e40f0f8cfa4226a80e4695fedafe6c57e"},
+    {file = "protobuf-3.18.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:700787cb56b4cb7b8ed5f7d197b9d8f30080f257f3c7431eec1fdd8060660929"},
+    {file = "protobuf-3.18.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:e9bffd52d6ee039a1cafb72475b2900c6fd0f0dca667fb7a09af0a3e119e78cb"},
+    {file = "protobuf-3.18.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8117b52c2531e4033f7d02b9be5a78564da41a8b02c255e1b731ad4bd75e7dc0"},
+    {file = "protobuf-3.18.3-cp38-cp38-win32.whl", hash = "sha256:15cdecb0d192ab5f17cdc21a9c0ae7b5c6c4451e42c8a888a4f3344c190e369c"},
+    {file = "protobuf-3.18.3-cp38-cp38-win_amd64.whl", hash = "sha256:e68ad00695547d9397dd14abd3efba23cb31cef67228f4512d41396971889812"},
+    {file = "protobuf-3.18.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:474247630834f93214fafce49d2ee6ff4c036c8c5382b88432b7eae6f08f131b"},
+    {file = "protobuf-3.18.3-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:a7f91a4e5bf3cc58b2830c9cb01b04ac5e211c288048e9296cd407ec0455fb89"},
+    {file = "protobuf-3.18.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6380aae2683d0d1b41199e591c8ba06f867e8a778d44309af87073c1b34a9f3a"},
+    {file = "protobuf-3.18.3-cp39-cp39-win32.whl", hash = "sha256:98d414513ec44bb3ba77ebdeffcbbe6ebbf3630c767d37a285890c2414fdd4e2"},
+    {file = "protobuf-3.18.3-cp39-cp39-win_amd64.whl", hash = "sha256:93bca9aaeee8008e15696c2a6b5e56b992da03f9d237ff54310e397d635f8305"},
+    {file = "protobuf-3.18.3-py2.py3-none-any.whl", hash = "sha256:abbcb8ecd19cfb729b9b71f9a453e37c0c1c017be4bff47804ff25150685386d"},
+    {file = "protobuf-3.18.3.tar.gz", hash = "sha256:196a153e487c0e20d62259872bbf2e1c4fa18e2ce97e20984fcbf9d8b151058d"},
+]
+pyrapl = [
+    {file = "pyRAPL-0.2.3.1-py2.py3-none-any.whl", hash = "sha256:508c832f7f80fd32e9fdd1194630483c68fdde40bf540537b47502d37295ec76"},
+    {file = "pyRAPL-0.2.3.1.tar.gz", hash = "sha256:c92e7e0644ceee2e55a312d515fc35de8941abd8d810095383e02183afa29b77"},
+]
+pyyaml = [
+    {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
+    {file = "PyYAML-6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
+    {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
+    {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
+    {file = "PyYAML-6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d4b0ba9512519522b118090257be113b9468d804b19d63c71dbcf4a48fa32358"},
+    {file = "PyYAML-6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:81957921f441d50af23654aa6c5e5eaf9b06aba7f0a19c18a538dc7ef291c5a1"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afa17f5bc4d1b10afd4466fd3a44dc0e245382deca5b3c353d8b757f9e3ecb8d"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:432557aa2c09802be39460360ddffd48156e30721f5e8d917f01d31694216782"},
+    {file = "PyYAML-6.0-cp311-cp311-win32.whl", hash = "sha256:bfaef573a63ba8923503d27530362590ff4f576c626d86a9fed95822a8255fd7"},
+    {file = "PyYAML-6.0-cp311-cp311-win_amd64.whl", hash = "sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf"},
+    {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4"},
+    {file = "PyYAML-6.0-cp36-cp36m-win32.whl", hash = "sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293"},
+    {file = "PyYAML-6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:07751360502caac1c067a8132d150cf3d61339af5691fe9e87803040dbc5db57"},
+    {file = "PyYAML-6.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:473f9edb243cb1935ab5a084eb238d842fb8f404ed2193a915d1784b5a6b5fc0"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ce82d761c532fe4ec3f87fc45688bdd3a4c1dc5e0b4a19814b9009a29baefd4"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:231710d57adfd809ef5d34183b8ed1eeae3f76459c18fb4a0b373ad56bedcdd9"},
+    {file = "PyYAML-6.0-cp37-cp37m-win32.whl", hash = "sha256:c5687b8d43cf58545ade1fe3e055f70eac7a5a1a0bf42824308d868289a95737"},
+    {file = "PyYAML-6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:d15a181d1ecd0d4270dc32edb46f7cb7733c7c508857278d3d378d14d606db2d"},
+    {file = "PyYAML-6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0b4624f379dab24d3725ffde76559cff63d9ec94e1736b556dacdfebe5ab6d4b"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:213c60cd50106436cc818accf5baa1aba61c0189ff610f64f4a3e8c6726218ba"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287"},
+    {file = "PyYAML-6.0-cp38-cp38-win32.whl", hash = "sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78"},
+    {file = "PyYAML-6.0-cp38-cp38-win_amd64.whl", hash = "sha256:1e4747bc279b4f613a09eb64bba2ba602d8a6664c6ce6396a4d0cd413a50ce07"},
+    {file = "PyYAML-6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b"},
+    {file = "PyYAML-6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0"},
+    {file = "PyYAML-6.0-cp39-cp39-win32.whl", hash = "sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb"},
+    {file = "PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
+    {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
+]
+ruff = [
+    {file = "ruff-0.0.254-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:dd58c500d039fb381af8d861ef456c3e94fd6855c3d267d6c6718c9a9fe07be0"},
+    {file = "ruff-0.0.254-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:688379050ae05394a6f9f9c8471587fd5dcf22149bd4304a4ede233cc4ef89a1"},
+    {file = "ruff-0.0.254-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ac1429be6d8bd3db0bf5becac3a38bd56f8421447790c50599cd90fd53417ec4"},
+    {file = "ruff-0.0.254-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:059a380c08e849b6f312479b18cc63bba2808cff749ad71555f61dd930e3c9a2"},
+    {file = "ruff-0.0.254-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b3f15d5d033fd3dcb85d982d6828ddab94134686fac2c02c13a8822aa03e1321"},
+    {file = "ruff-0.0.254-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:8deba44fd563361c488dedec90dc330763ee0c01ba54e17df54ef5820079e7e0"},
+    {file = "ruff-0.0.254-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ef20bf798ffe634090ad3dc2e8aa6a055f08c448810a2f800ab716cc18b80107"},
+    {file = "ruff-0.0.254-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0deb1d7226ea9da9b18881736d2d96accfa7f328c67b7410478cc064ad1fa6aa"},
+    {file = "ruff-0.0.254-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:27d39d697fdd7df1f2a32c1063756ee269ad8d5345c471ee3ca450636d56e8c6"},
+    {file = "ruff-0.0.254-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:2fc21d060a3197ac463596a97d9b5db2d429395938b270ded61dd60f0e57eb21"},
+    {file = "ruff-0.0.254-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f70dc93bc9db15cccf2ed2a831938919e3e630993eeea6aba5c84bc274237885"},
+    {file = "ruff-0.0.254-py3-none-musllinux_1_2_i686.whl", hash = "sha256:09c764bc2bd80c974f7ce1f73a46092c286085355a5711126af351b9ae4bea0c"},
+    {file = "ruff-0.0.254-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:d4385cdd30153b7aa1d8f75dfd1ae30d49c918ead7de07e69b7eadf0d5538a1f"},
+    {file = "ruff-0.0.254-py3-none-win32.whl", hash = "sha256:c38291bda4c7b40b659e8952167f386e86ec29053ad2f733968ff1d78b4c7e15"},
+    {file = "ruff-0.0.254-py3-none-win_amd64.whl", hash = "sha256:e15742df0f9a3615fbdc1ee9a243467e97e75bf88f86d363eee1ed42cedab1ec"},
+    {file = "ruff-0.0.254-py3-none-win_arm64.whl", hash = "sha256:b435afc4d65591399eaf4b2af86e441a71563a2091c386cadf33eaa11064dc09"},
+    {file = "ruff-0.0.254.tar.gz", hash = "sha256:0eb66c9520151d3bd950ea43b3a088618a8e4e10a5014a72687881e6f3606312"},
+]
+setuptools = [
+    {file = "setuptools-67.6.0-py3-none-any.whl", hash = "sha256:b78aaa36f6b90a074c1fa651168723acbf45d14cb1196b6f02c0fd07f17623b2"},
+    {file = "setuptools-67.6.0.tar.gz", hash = "sha256:2ee892cd5f29f3373097f5a814697e397cf3ce313616df0af11231e2ad118077"},
+]
+toml = [
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
+torch = [
+    {file = "torch-1.13.1-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:fd12043868a34a8da7d490bf6db66991108b00ffbeecb034228bfcbbd4197143"},
+    {file = "torch-1.13.1-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:d9fe785d375f2e26a5d5eba5de91f89e6a3be5d11efb497e76705fdf93fa3c2e"},
+    {file = "torch-1.13.1-cp310-cp310-win_amd64.whl", hash = "sha256:98124598cdff4c287dbf50f53fb455f0c1e3a88022b39648102957f3445e9b76"},
+    {file = "torch-1.13.1-cp310-none-macosx_10_9_x86_64.whl", hash = "sha256:393a6273c832e047581063fb74335ff50b4c566217019cc6ace318cd79eb0566"},
+    {file = "torch-1.13.1-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:0122806b111b949d21fa1a5f9764d1fd2fcc4a47cb7f8ff914204fd4fc752ed5"},
+    {file = "torch-1.13.1-cp311-cp311-manylinux1_x86_64.whl", hash = "sha256:22128502fd8f5b25ac1cd849ecb64a418382ae81dd4ce2b5cebaa09ab15b0d9b"},
+    {file = "torch-1.13.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:76024be052b659ac1304ab8475ab03ea0a12124c3e7626282c9c86798ac7bc11"},
+    {file = "torch-1.13.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:ea8dda84d796094eb8709df0fcd6b56dc20b58fdd6bc4e8d7109930dafc8e419"},
+    {file = "torch-1.13.1-cp37-cp37m-win_amd64.whl", hash = "sha256:2ee7b81e9c457252bddd7d3da66fb1f619a5d12c24d7074de91c4ddafb832c93"},
+    {file = "torch-1.13.1-cp37-none-macosx_10_9_x86_64.whl", hash = "sha256:0d9b8061048cfb78e675b9d2ea8503bfe30db43d583599ae8626b1263a0c1380"},
+    {file = "torch-1.13.1-cp37-none-macosx_11_0_arm64.whl", hash = "sha256:f402ca80b66e9fbd661ed4287d7553f7f3899d9ab54bf5c67faada1555abde28"},
+    {file = "torch-1.13.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:727dbf00e2cf858052364c0e2a496684b9cb5aa01dc8a8bc8bbb7c54502bdcdd"},
+    {file = "torch-1.13.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:df8434b0695e9ceb8cc70650afc1310d8ba949e6db2a0525ddd9c3b2b181e5fe"},
+    {file = "torch-1.13.1-cp38-cp38-win_amd64.whl", hash = "sha256:5e1e722a41f52a3f26f0c4fcec227e02c6c42f7c094f32e49d4beef7d1e213ea"},
+    {file = "torch-1.13.1-cp38-none-macosx_10_9_x86_64.whl", hash = "sha256:33e67eea526e0bbb9151263e65417a9ef2d8fa53cbe628e87310060c9dcfa312"},
+    {file = "torch-1.13.1-cp38-none-macosx_11_0_arm64.whl", hash = "sha256:eeeb204d30fd40af6a2d80879b46a7efbe3cf43cdbeb8838dd4f3d126cc90b2b"},
+    {file = "torch-1.13.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:50ff5e76d70074f6653d191fe4f6a42fdbe0cf942fbe2a3af0b75eaa414ac038"},
+    {file = "torch-1.13.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:2c3581a3fd81eb1f0f22997cddffea569fea53bafa372b2c0471db373b26aafc"},
+    {file = "torch-1.13.1-cp39-cp39-win_amd64.whl", hash = "sha256:0aa46f0ac95050c604bcf9ef71da9f1172e5037fdf2ebe051962d47b123848e7"},
+    {file = "torch-1.13.1-cp39-none-macosx_10_9_x86_64.whl", hash = "sha256:6930791efa8757cb6974af73d4996b6b50c592882a324b8fb0589c6a9ba2ddaf"},
+    {file = "torch-1.13.1-cp39-none-macosx_11_0_arm64.whl", hash = "sha256:e0df902a7c7dd6c795698532ee5970ce898672625635d885eade9976e5a04949"},
+]
+typing-extensions = [
+    {file = "typing_extensions-4.5.0-py3-none-any.whl", hash = "sha256:fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4"},
+    {file = "typing_extensions-4.5.0.tar.gz", hash = "sha256:5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb"},
+]
+wheel = [
+    {file = "wheel-0.38.4-py3-none-any.whl", hash = "sha256:b60533f3f5d530e971d6737ca6d58681ee434818fab630c83a734bb10c083ce8"},
+    {file = "wheel-0.38.4.tar.gz", hash = "sha256:965f5259b566725405b05e7cf774052044b1ed30119b5d586b2703aafe8719ac"},
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ torch = "*"
 nvidia-ml-py3 = "*"
 toml = "^0.10.2"
 pyRAPL = "^0.2.3"
+ruff = "^0.0.254"
 
 [tool.poetry.dev-dependencies]
 

--- a/skyline/__main__.py
+++ b/skyline/__main__.py
@@ -1,5 +1,4 @@
 import argparse
-import enum
 import sys
 
 import skyline

--- a/skyline/analysis/request_manager.py
+++ b/skyline/analysis/request_manager.py
@@ -4,7 +4,6 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 
 from skyline.analysis.runner import analyze_project
-from skyline.config import Config
 from skyline.exceptions import AnalysisError
 from skyline.nvml import NVML
 import skyline.protocol_gen.innpv_pb2 as pm

--- a/skyline/analysis/session.py
+++ b/skyline/analysis/session.py
@@ -549,9 +549,9 @@ def _wrap_providers_with_validators(
             ).with_file_context(entry_point)
 
         try:
-            input_iter = iter(inputs)
+            iter(inputs)
             return inputs
-        except TypeError as ex:
+        except TypeError:
             raise AnalysisError(
                 "The input provider function must return an iterable that "
                 "contains the inputs for the model."

--- a/skyline/commands/interactive.py
+++ b/skyline/commands/interactive.py
@@ -1,6 +1,5 @@
 import logging
 import signal
-import subprocess
 import threading
 
 from skyline.initialization import (
@@ -48,7 +47,6 @@ def register_command(subparsers):
     parser.set_defaults(func=main)
 
 def actual_main(args):
-    from skyline.config import Config
     from skyline.server import SkylineServer
 
     should_shutdown = threading.Event()

--- a/skyline/commands/measurements.py
+++ b/skyline/commands/measurements.py
@@ -60,7 +60,6 @@ def make_measurements(session, batch_size):
 
 def actual_main(args):
     from skyline.analysis.session import AnalysisSession
-    from skyline.config import Config
     from skyline.exceptions import AnalysisError
 
     if os.path.exists(args.output):

--- a/skyline/commands/memory.py
+++ b/skyline/commands/memory.py
@@ -37,7 +37,6 @@ def register_command(subparsers):
 
 def actual_main(args):
     from skyline.analysis.session import AnalysisSession
-    from skyline.config import Config
     from skyline.exceptions import AnalysisError
 
     if os.path.exists(args.output):

--- a/skyline/commands/prediction_models.py
+++ b/skyline/commands/prediction_models.py
@@ -55,7 +55,6 @@ def get_model(session, batch_size):
 
 def actual_main(args):
     from skyline.analysis.session import AnalysisSession
-    from skyline.config import Config
     from skyline.exceptions import AnalysisError
 
     if os.path.exists(args.output):

--- a/skyline/commands/time.py
+++ b/skyline/commands/time.py
@@ -38,7 +38,6 @@ def register_command(subparsers):
 
 def actual_main(args):
     from skyline.analysis.session import AnalysisSession
-    from skyline.config import Config
     from skyline.exceptions import AnalysisError
 
     if os.path.exists(args.output):

--- a/skyline/energy/measurer.py
+++ b/skyline/energy/measurer.py
@@ -19,7 +19,7 @@ class CPUMeasurer:
             energy = self.sensor.energy()
             self.last_cpu = np.array(energy[0::2])
             self.last_dram = np.array(energy[1::2])
-        except Exception as e:
+        except Exception:
             print("Warning. Failed to get CPU energy")
 
     def measurer_measure(self):
@@ -32,7 +32,6 @@ class CPUMeasurer:
 
         # Compare against last measurement to determine energy since last measure
         diff_cpu = cpu - self.last_cpu
-        diff_dram = dram - self.last_dram
         
         # 1J = 10^6 uJ
         # The cpu used this much since the last measurement

--- a/skyline/evaluate.py
+++ b/skyline/evaluate.py
@@ -1,5 +1,4 @@
 import argparse
-import enum
 import sys
 
 import skyline.commands.measurements

--- a/skyline/initialization.py
+++ b/skyline/initialization.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import sys
 
 logger = logging.getLogger(__name__)
@@ -42,11 +41,6 @@ def _validate_dependencies():
     # NOTE: If you make a change here, make sure to update the INSTALL_REQUIRES
     #       list in setup.py as well.
     try:
-        import yaml # pyyaml on PyPI
-        import pynvml # nvidia-ml-py3 on PyPI
-        import google.protobuf # protobuf on PyPI
-        import numpy
-        import torch
         return True
     except ImportError as ex:
         logger.error(

--- a/skyline/io/connection_acceptor.py
+++ b/skyline/io/connection_acceptor.py
@@ -1,4 +1,3 @@
-import os
 import select
 import socket
 import logging

--- a/skyline/models/analysis.py
+++ b/skyline/models/analysis.py
@@ -1,4 +1,3 @@
-from skyline.models.source_map import Position
 
 
 class OperationInfo:

--- a/skyline/protocol/message_handler.py
+++ b/skyline/protocol/message_handler.py
@@ -2,7 +2,7 @@ import collections
 import logging
 import os
 
-from skyline.exceptions import AnalysisError, NoConnectionError
+from skyline.exceptions import NoConnectionError
 
 import skyline.protocol_gen.innpv_pb2 as pm
 

--- a/skyline/protocol/message_sender.py
+++ b/skyline/protocol/message_sender.py
@@ -2,9 +2,7 @@ import os
 import logging
 import pynvml
 import platform
-from random import random
 
-from skyline.config import Config
 from skyline.exceptions import NoConnectionError
 
 import skyline.protocol_gen.innpv_pb2 as pm

--- a/skyline/skyline.py
+++ b/skyline/skyline.py
@@ -1,8 +1,6 @@
 import argparse
-import enum
 import sys
 
-import toml
 
 import skyline
 import skyline.commands.interactive

--- a/skyline/tests/test_lru_cache.py
+++ b/skyline/tests/test_lru_cache.py
@@ -118,7 +118,7 @@ class LRUCacheListTests(unittest.TestCase):
     def test_list_move_three(self):
         n1 = self.list.add_to_front(1, 1)
         n2 = self.list.add_to_front(2, 2)
-        n3 = self.list.add_to_front(3, 3)
+        self.list.add_to_front(3, 3)
 
         self.list.move_to_front(n1)
         self.assertEqual(self.list_to_array(), [(1, 1), (3, 3), (2, 2)])
@@ -140,7 +140,7 @@ class LRUCacheListTests(unittest.TestCase):
 
     def test_list_move_two(self):
         n1 = self.list.add_to_front(1, 1)
-        n2 = self.list.add_to_front(2, 2)
+        self.list.add_to_front(2, 2)
         self.assertEqual(self.list_to_array(), [(2, 2), (1, 1)])
 
         self.list.move_to_front(n1)
@@ -170,7 +170,7 @@ class LRUCacheListTests(unittest.TestCase):
 
     def test_list_remove_back_two(self):
         n1 = self.list.add_to_front(1, 1)
-        n2 = self.list.add_to_front(2, 2)
+        self.list.add_to_front(2, 2)
         self.assertEqual(self.list.size, 2)
         self.assertEqual(self.list_to_array(), [(2, 2), (1, 1)])
         removed = self.list.remove_back()
@@ -181,8 +181,8 @@ class LRUCacheListTests(unittest.TestCase):
 
     def test_list_remove_back_three(self):
         n1 = self.list.add_to_front(1, 1)
-        n2 = self.list.add_to_front(2, 2)
-        n3 = self.list.add_to_front(3, 3)
+        self.list.add_to_front(2, 2)
+        self.list.add_to_front(3, 3)
         self.assertEqual(self.list.size, 3)
         self.assertEqual(self.list_to_array(), [(3, 3), (2, 2), (1, 1)])
         removed = self.list.remove_back()

--- a/skyline/tracking/memory/report.py
+++ b/skyline/tracking/memory/report.py
@@ -1,6 +1,5 @@
 import collections
 import enum
-import os
 
 from skyline.tracking.base import ReportBase, ReportBuilderBase
 import skyline.tracking.memory.report_queries as queries

--- a/skyline/tracking/memory/weights.py
+++ b/skyline/tracking/memory/weights.py
@@ -1,5 +1,4 @@
 import torch
-import inspect
 import weakref
 
 from skyline.tracking.base import TrackerBase

--- a/skyline/tracking/time/operation.py
+++ b/skyline/tracking/time/operation.py
@@ -1,6 +1,5 @@
 import collections
 
-import torch
 
 from skyline.tracking.call_stack import CallStack
 from skyline.tracking.base import TrackerBase

--- a/skyline/tracking/time/report.py
+++ b/skyline/tracking/time/report.py
@@ -1,5 +1,4 @@
 import collections
-import os
 
 from skyline.tracking.base import ReportBase, ReportBuilderBase
 import skyline.tracking.time.report_queries as queries

--- a/skyline/tracking/utils.py
+++ b/skyline/tracking/utils.py
@@ -1,6 +1,5 @@
 import re
 
-import torch
 
 DUNDER_REGEX = re.compile('__(?P<name>.+)__')
 

--- a/skyline/user_code_utils.py
+++ b/skyline/user_code_utils.py
@@ -1,5 +1,4 @@
 import contextlib
-import os
 import sys
 
 from skyline.exceptions import exceptions_as_analysis_errors

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -20,13 +20,13 @@ class TestSkylineDatabase:
 
     # try adding invalid entry and test if it is added
     def test_invalid_entry_too_short(self):
-        assert(self.energy_table_interface.is_valid_entry([]) == False)
+        assert(self.energy_table_interface.is_valid_entry([]) is False)
     
     def test_invalid_entry_too_long(self):
-        assert(self.energy_table_interface.is_valid_entry([1,2,3,4]) == False)
+        assert(self.energy_table_interface.is_valid_entry([1, 2, 3, 4]) is False)
 
     def test_invalid_entry_wrong_types(self):
-        assert(self.energy_table_interface.is_valid_entry([None, None, None, None, None]) == False)
+        assert(self.energy_table_interface.is_valid_entry([None, None, None, None, None]) is False)
 
     def test_adding_valid_entry(self):
         params = ["entry_point", random.random(), random.random()]

--- a/test/utils.py
+++ b/test/utils.py
@@ -9,7 +9,7 @@ from skyline.protocol_gen import innpv_pb2
 def stream_monitor(stream, callback=None):
     try:
         for line in stream: callback(line)
-    except OSError as e:
+    except OSError:
         print(f"Closing listener for stream {stream}")
 
 def socket_monitor(socket, callback=None):
@@ -19,7 +19,7 @@ def socket_monitor(socket, callback=None):
             msg = socket.recv(msg_len)
             print(f"Received message of length {msg_len}")
             callback(msg)
-    except OSError as e:
+    except OSError:
         print(f"Closing listener for socket {socket}")
 
 class BackendContext:


### PR DESCRIPTION
Recently I saw someone post a link to [ruff](https://beta.ruff.rs/docs/) - Fast Python Linter. So I ran it against this code base and saw bunch of warnings. Some of which have been automatically fixed by `ruff`, but there remains another 21 that would need to be addressed, see below:
```zsh
poetry run ruff check --ignore E501  .     
examples/densenet/densenet.py:53:9: F811 Redefinition of unused `forward` from line 48
skyline/analysis/request_manager.py:137:9: E722 Do not use bare `except`
skyline/analysis/request_manager.py:166:9: E722 Do not use bare `except`
skyline/analysis/request_manager.py:174:9: E722 Do not use bare `except`
skyline/analysis/request_manager.py:182:9: E722 Do not use bare `except`
skyline/analysis/request_manager.py:190:9: E722 Do not use bare `except`
skyline/analysis/request_manager.py:198:9: E722 Do not use bare `except`
skyline/energy/measurer.py:27:31: E701 Multiple statements on one line (colon)
skyline/energy/measurer.py:50:32: E701 Multiple statements on one line (colon)
skyline/io/connection.py:94:9: E722 Do not use bare `except`
skyline/io/connection_acceptor.py:80:9: E722 Do not use bare `except`
skyline/profiler/iteration.py:222:25: E701 Multiple statements on one line (colon)
skyline/protocol/message_handler.py:153:9: E722 Do not use bare `except`
skyline/tracking/memory/activations.py:182:47: F821 Undefined name `tensor_iterable`
test/test_driver.py:3:1: F403 `from utils import *` used; unable to detect undefined names
test/test_driver.py:6:14: F405 `json` may be undefined, or defined from star imports: `utils`
test/test_driver.py:15:15: F405 `BackendContext` may be undefined, or defined from star imports: `utils`
test/test_driver.py:18:12: F405 `SkylineSession` may be undefined, or defined from star imports: `utils`
test/test_driver.py:19:29: E701 Multiple statements on one line (colon)
test/test_driver.py:23:42: E701 Multiple statements on one line (colon)
test/utils.py:11:27: E701 Multiple statements on one line (colon)
Found 21 errors.

```

Also, I've added [CodeClimate Quality](https://codeclimate.com/quality) integration to help us improve the codebase over time. Let's see how it looks on PRs.