### PR TITLE
changed create release branch step

### DIFF
--- a/.github/workflows/build-and-publish-new-version.yml
+++ b/.github/workflows/build-and-publish-new-version.yml
@@ -30,7 +30,9 @@ jobs:
 
       - name: Create release branch
         run: |
-          git branch release/${{ github.event.inputs.tag }}
+          git checkout -b release/${{ github.event.inputs.tag }}
+          git fetch
+          git branch --set-upstream-to=origin/main release/${{ github.event.inputs.tag }}
 
       - name: Update version number
         run: |


### PR DESCRIPTION
- previous release steps threw an error "aborted: you must first push the current branch to a remote, or use the --head flag"
- changed "Create release branch" step