### PR TITLE
changes to session.py [habitat section]

### DIFF
--- a/deepview_profile/analysis/session.py
+++ b/deepview_profile/analysis/session.py
@@ -246,8 +246,7 @@ class AnalysisSession:
                 habitat.Device.RTX3090,
                 habitat.Device.A40,
                 habitat.Device.A4000,
-                habitat.Device.RTX4000,
-                habitat.Device.RTX3060Ti
+                habitat.Device.RTX4000
             ]
 
             # Detect source GPU

--- a/deepview_profile/analysis/session.py
+++ b/deepview_profile/analysis/session.py
@@ -247,6 +247,7 @@ class AnalysisSession:
                 habitat.Device.A40,
                 habitat.Device.A4000,
                 habitat.Device.RTX4000,
+                habitat.Device.RTX3060Ti
             ]
 
             # Detect source GPU
@@ -264,7 +265,7 @@ class AnalysisSession:
                 None if logging.root.level > logging.DEBUG else habitat.Device.T4
             )
             for device in DEVICES:
-                if device.name in split_source_device_name:
+                if device.name in "".join(split_source_device_name):
                     source_device = device
             pynvml.nvmlShutdown()
             if not source_device:
@@ -331,7 +332,9 @@ class AnalysisSession:
             message = str(ex)
             logger.error(message)
             resp.analysis_error.error_message = message
-        except Exception:
+        except Exception as ex:
+            message = str(ex)
+            logger.error(message)
             logger.error("There was an error running DeepView Predict")
             resp.analysis_error.error_message = (
                 "There was an error running DeepView Predict"


### PR DESCRIPTION
- When testing my 3060Ti with habitat I ran into some issues with the naming. source_device_name gives an array ['NVIDIA', 'GeForce', 'RTX', '3060', 'Ti'], but device.name is RTX3060Ti. To match correctly I needed to join the array.
- Added logger.error(message)