### PR TITLE
Allow unassociated weight during trace

### DIFF
--- a/deepview_profile/tracking/breakdown.py
+++ b/deepview_profile/tracking/breakdown.py
@@ -1,6 +1,7 @@
 import collections
 import math
 import os
+import warnings
 
 HierarchicalBreakdown = collections.namedtuple(
     'HierarchicalBreakdown', ['operations', 'weights', 'peak_usage_bytes'])
@@ -48,8 +49,7 @@ class HierarchicalBreakdownBuilder:
     def add_weight_entry(
             self, weight_name, size_bytes, grad_size_bytes, stack_context):
         if len(stack_context.frames) == 0:
-            raise ValueError(
-                'Adding weight entry with no context to the breakdown.')
+            warnings.warn(f"{weight_name} has no accociated context")
 
         for entry in self._traverse_and_insert(
                 self._weight_root, weight_name, stack_context):


### PR DESCRIPTION
This PR allows the HugginFace demo to work when LoRA is enabled. 